### PR TITLE
feat: SearchResult 화면 검색창 입력 비활성화 및 버튼 기능 개선

### DIFF
--- a/lib/features/home/views/home_screen.dart
+++ b/lib/features/home/views/home_screen.dart
@@ -55,19 +55,25 @@ class HomeScreen extends StatelessWidget {
 
               const SizedBox(height: 30),
 
-              // 🔹 아이콘 리스트
+              // 🔹 아이콘 리스트 여기에 수정해주세여
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 12),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: controller.iconItems.map((item) {
-                    return _IconLabelItem(
-                      imageName: item['image']!,
-                      label: item['label']!,
+                    return GestureDetector(
+                      onTap: () {
+                        // TODO: 여기에 onTap 기능을 넣으면 됩니다~
+                      },
+                      child: _IconLabelItem(
+                        imageName: item['image']!,
+                        label: item['label']!,
+                      ),
                     );
                   }).toList(),
                 ),
               ),
+
 
               const SizedBox(height: 24),
               Padding(

--- a/lib/features/search/controllers/search_result_controller.dart
+++ b/lib/features/search/controllers/search_result_controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../models/contest_model.dart';
 
@@ -14,9 +15,20 @@ class SearchResultController extends GetxController {
   // 💾 저장한 공모전 리스트
   final RxList<Contest> savedContests = <Contest>[].obs;
 
+  // 🔤 검색창 제어용 컨트롤러
+  final TextEditingController searchController = TextEditingController();
+
+  // ✅ 입력 여부 추적용 RxBool (Obx에서 사용)
+  final RxBool isSearching = false.obs;
+
   @override
   void onInit() {
     super.onInit();
+
+    searchController.addListener(() {
+      isSearching.value = searchController.text.trim().isNotEmpty;
+    });
+
     // 🧪 테스트용 공모전 데이터 미리 로드
     allContests.addAll([
       Contest(
@@ -41,22 +53,24 @@ class SearchResultController extends GetxController {
         tags: ['환경', '아이디어'],
       ),
     ]);
-    results.assignAll(allContests); // 초기화 시 결과도 전체 공모전으로 설정
+    results.assignAll(allContests);
   }
 
   /// 🔍 키워드로 검색 실행
   void search(String query) {
     keyword.value = query;
+    searchController.text = query;
 
     final lowerQuery = query.toLowerCase();
     results.value = allContests.where((contest) =>
     contest.title.toLowerCase().contains(lowerQuery) ||
         contest.reward.toLowerCase().contains(lowerQuery) ||
         contest.eligibility.toLowerCase().contains(lowerQuery) ||
-        contest.tags.any((tag) => tag.toLowerCase().contains(lowerQuery))).toList();
+        contest.tags.any((tag) => tag.toLowerCase().contains(lowerQuery))
+    ).toList();
   }
 
-  /// ⭐ 저장 또는 저장 취소 (title 기준으로 중복 방지)
+  /// ⭐ 저장 또는 저장 취소
   void toggleSave(Contest contest) {
     final index = savedContests.indexWhere((c) => c.title == contest.title);
     if (index != -1) {
@@ -64,11 +78,17 @@ class SearchResultController extends GetxController {
     } else {
       savedContests.add(contest);
     }
-    results.refresh(); // ✅ 검색 결과도 UI 갱신되도록 강제 리빌드
+    results.refresh();
   }
 
-  /// ✅ 저장 여부 확인 (title 기준)
+  /// ✅ 저장 여부 확인
   bool isSaved(Contest contest) {
     return savedContests.any((c) => c.title == contest.title);
+  }
+
+  @override
+  void onClose() {
+    searchController.dispose();
+    super.onClose();
   }
 }

--- a/lib/features/search/views/search_result_screen.dart
+++ b/lib/features/search/views/search_result_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:knowme_frontend/features/search/views/search_screen.dart';
 import '../../../shared/widgets/base_scaffold.dart';
 import '../controllers/search_result_controller.dart';
 import '../models/contest_model.dart';
-import 'search_screen.dart';
 
 class SearchResultScreen extends StatefulWidget {
   const SearchResultScreen({super.key});
@@ -29,10 +29,11 @@ class _SearchResultScreenState extends State<SearchResultScreen> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   SearchBarWithAction(
-                    controller: TextEditingController(),
+                    controller: controller.searchController,
                     isSearching: false,
                     onSearch: () {},
-                    onCancel: () {},
+                    onCancel: () => Get.back(),
+                    readOnly: true,
                   ),
                   const SizedBox(height: 20),
                   const Text(
@@ -52,7 +53,7 @@ class _SearchResultScreenState extends State<SearchResultScreen> {
           ),
           SliverPadding(
             padding: const EdgeInsets.symmetric(horizontal: 20),
-            sliver: Obx(() => SliverGrid(
+            sliver: SliverGrid(
               delegate: SliverChildBuilderDelegate(
                     (context, index) {
                   final item = controller.results[index];
@@ -70,7 +71,7 @@ class _SearchResultScreenState extends State<SearchResultScreen> {
                 mainAxisSpacing: 12,
                 childAspectRatio: 180 / 240,
               ),
-            )),
+            ),
           ),
           SliverToBoxAdapter(
             child: Padding(
@@ -135,7 +136,7 @@ class _SearchResultScreenState extends State<SearchResultScreen> {
           ),
           SliverPadding(
             padding: const EdgeInsets.symmetric(horizontal: 20),
-            sliver: Obx(() => SliverGrid(
+            sliver: SliverGrid(
               delegate: SliverChildBuilderDelegate(
                     (context, index) {
                   final item = controller.savedContests[index];
@@ -153,7 +154,7 @@ class _SearchResultScreenState extends State<SearchResultScreen> {
                 mainAxisSpacing: 12,
                 childAspectRatio: 180 / 240,
               ),
-            )),
+            ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 24)),
         ],
@@ -167,7 +168,11 @@ class _ContestCard extends StatelessWidget {
   final VoidCallback onSave;
   final bool isSaved;
 
-  const _ContestCard({required this.contest, required this.onSave, required this.isSaved});
+  const _ContestCard({
+    required this.contest,
+    required this.onSave,
+    required this.isSaved,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/search/views/search_screen.dart
+++ b/lib/features/search/views/search_screen.dart
@@ -18,17 +18,17 @@ class SearchScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Obx(() => SearchBarWithAction(
-                  controller: controller.searchController,
-                  isSearching: controller.isSearching.value,
-                  onSearch: controller.handleSearch,
-                  onCancel: () => Navigator.pop(context),
-                )),
+              controller: controller.searchController,
+              isSearching: controller.isSearching.value,
+              onSearch: controller.handleSearch,
+              onCancel: () => Navigator.pop(context),
+              readOnly: false, // 🔑 SearchScreen에서는 입력 가능
+            )),
             const SizedBox(height: 20),
             _SearchHeader(onClearAll: controller.clearRecentSearches),
             const SizedBox(height: 6),
             Container(height: 1, color: const Color(0xFFE5E5E5)),
             const SizedBox(height: 8),
-            // ✅ 여기서 타입도 search.SearchController로 명시
             Obx(() => Expanded(child: _buildRecentSearchList(controller))),
           ],
         ),
@@ -53,12 +53,12 @@ class SearchScreen extends StatelessWidget {
   }
 }
 
-// ✅ 검색창과 오른쪽 '검색/취소' 버튼
 class SearchBarWithAction extends StatelessWidget {
   final TextEditingController controller;
   final bool isSearching;
   final VoidCallback onSearch;
   final VoidCallback onCancel;
+  final bool readOnly;
 
   const SearchBarWithAction({
     super.key,
@@ -66,6 +66,7 @@ class SearchBarWithAction extends StatelessWidget {
     required this.isSearching,
     required this.onSearch,
     required this.onCancel,
+    this.readOnly = false,
   });
 
   @override
@@ -88,6 +89,7 @@ class SearchBarWithAction extends StatelessWidget {
                 Expanded(
                   child: TextField(
                     controller: controller,
+                    readOnly: readOnly, // ✅ 입력 가능 여부 제어
                     decoration: const InputDecoration(
                       border: InputBorder.none,
                       hintText: '검색어를 입력해 주세요',
@@ -113,7 +115,7 @@ class SearchBarWithAction extends StatelessWidget {
           child: Text(
             isSearching ? '검색' : '취소',
             style: const TextStyle(
-              color: Color(0xFF72787F),
+              color: Color(0xFF0068E5),
               fontSize: 14,
               fontFamily: 'Pretendard',
               fontWeight: FontWeight.w500,
@@ -126,7 +128,6 @@ class SearchBarWithAction extends StatelessWidget {
   }
 }
 
-// ✅ 최근 검색어 헤더
 class _SearchHeader extends StatelessWidget {
   final VoidCallback onClearAll;
 
@@ -166,7 +167,6 @@ class _SearchHeader extends StatelessWidget {
   }
 }
 
-// ✅ 최근 검색어 아이템
 class RecentSearchItem extends StatelessWidget {
   final String text;
   final VoidCallback onRemove;

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -12,6 +12,8 @@ import '../features/membership/views/password_reset_success_screen.dart';
 import '../features/home/views/home_screen.dart';
 import '../features/ai_analysis/controllers/ai_analysis_controller.dart';
 import '../features/search/controllers/search_controller.dart';
+import '../features/search/controllers/search_result_controller.dart';
+import '../features/search/views/search_result_screen.dart';
 import '../features/search/views/search_screen.dart';
 import '../features/membership/controllers/login_controller.dart';
 import '../features/membership/controllers/find_id_passwd_controller.dart';
@@ -29,6 +31,8 @@ class AppRoutes {
   static const String passwordReset = '/password-reset';
   static const String passwordResetSuccess = '/password-reset-success';
   static const String search = '/search';
+  static const String searchResult = '/searchResult';
+
 
   // ✅ 새 라우트 추가
   static const String post = '/post';
@@ -110,5 +114,14 @@ class AppRoutes {
       }),
       transition: Transition.fadeIn,
     ),
+    GetPage(
+      name: AppRoutes.searchResult,
+      page: () => const SearchResultScreen(),
+      binding: BindingsBuilder(() {
+        Get.put(SearchResultController());
+      }),
+      transition: Transition.fadeIn,
+    ),
+
   ];
 }


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
검색 결과 화면의 상단 검색창에서 텍스트 입력이 되던 문제를 수정하고, 항상 "취소" 버튼만 보이도록 UI 동작을 변경했습니다. 
취소버튼을 누르면 검색창 화면으로 돌아가는 로직 추가했습니다.
GetX Obx 구조 개선을 통해 업데이트 오류를 해결했습니다.

## 🛠 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- `SearchBarWithAction` 컴포넌트에 `readOnly` 및 `isSearching` 제어 로직 적용
- `SearchResultScreen`에서 검색창 입력을 비활성화하고 "취소" 버튼만 표시되도록 고정
- 불필요한 Obx 제거로 GetX 위젯 오류 해결 (`The improper use of a GetX has been detected`)

## 🧪 테스트 체크리스트
<!-- 테스트 방법 및 결과를 설명해주세요 -->
- [x] SearchScreen에서 검색 수행 후 SearchResultScreen으로 정상 전환되는지 확인
- [x] SearchResultScreen에서 검색창이 비활성화되고 "취소" 버튼만 보이는지 확인
- [x] "취소" 버튼 클릭 시 SearchScreen으로 정상 복귀되는지 확인
- [x] 저장 버튼 기능(북마크)이 정상 동작하는지 확인

## 📸 스크린샷 또는 비디오
<!-- UI 변경사항이 있는 경우 스크린샷이나 GIF를 첨부해주세요 -->

## ➕ 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
